### PR TITLE
Avoid memory leak in parameter creation

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -185,11 +185,10 @@ public class PostgreSQLConnection: Connection {
         // At the moment we only create string parameters. Binary parameters should be added.
         for parameter in parameters {
             if parameter != nil {
-                let value = AnyCollection("\(parameter!)".utf8CString)
-                parameterPointers.append(UnsafeMutablePointer<Int8>.allocate(capacity: Int(value.count)))
-                for (index, byte) in value.enumerated() {
-                    parameterPointers[parameterPointers.count-1]![index] = byte
-                }
+                let parameterString = "\(parameter!)"
+                let count = parameterString.lengthOfBytes(using: .utf8) + 1
+                parameterPointers.append(UnsafeMutablePointer<Int8>.allocate(capacity: Int(count)))
+                memcpy(parameterPointers[parameterPointers.count-1]!, UnsafeRawPointer(parameterString), count)
                 parameterData.append(parameterPointers.last!)
             }
             else {

--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -184,8 +184,8 @@ public class PostgreSQLConnection: Connection {
         var parameterData = [UnsafePointer<Int8>?]()
         // At the moment we only create string parameters. Binary parameters should be added.
         for parameter in parameters {
-            if parameter != nil {
-                let parameterString = "\(parameter!)"
+            if let parameter = parameter {
+                let parameterString = String(describing: parameter)
                 let count = parameterString.lengthOfBytes(using: .utf8) + 1
                 parameterPointers.append(UnsafeMutablePointer<Int8>.allocate(capacity: Int(count)))
                 memcpy(parameterPointers[parameterPointers.count-1]!, UnsafeRawPointer(parameterString), count)


### PR DESCRIPTION
IBM-Swift/Swift-Kuery-PostgreSQL#8 Rewrite parameter passing to avoid memory leak