### PR TITLE
IBM-Swift/Swift-Kuery#70 Handle UUIDs

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLResultFetcher.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLResultFetcher.swift
@@ -232,6 +232,10 @@ public class PostgreSQLResultFetcher: ResultFetcher {
                 
             case .bool:
                 return Bool(value.withMemoryRebound(to: Bool.self, capacity: 1) { $0.pointee })
+                
+            case .uuid:
+                let uuid = UUID(uuid: uuid_t(value.withMemoryRebound(to: uuid_t.self, capacity: 1) { $0.pointee }))
+                return uuid.uuidString
             }
         }
     }

--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLType.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLType.swift
@@ -40,4 +40,6 @@ enum PostgreSQLType: UInt32 {
     case timetz = 1266
     case timestamp = 1114
     case timestamptz = 1184
+    
+    case uuid = 2950
 }

--- a/Tests/SwiftKueryPostgreSQLTests/CommonUtils.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/CommonUtils.swift
@@ -111,7 +111,7 @@ private func printResultAndGetRowsAsArray(_ result: QueryResult) -> [[Any?]]? {
     var rows: [[Any?]]? = nil
     if let resultSet = result.asResultSet {
         let titles = resultSet.titles
-        let length = titles.count > 6 ? 18 : 30
+        let length = titles.count > 6 ? 18 : 36
         for title in titles {
             print(title.padding(toLength: length, withPad: " ", startingAt: 0), terminator: "")
         }

--- a/Tests/SwiftKueryPostgreSQLTests/TestTypes.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestTypes.swift
@@ -27,12 +27,14 @@ let tableNumberTypes = "tableNumberTypesLinux"
 let tableBool = "tableBoolLinux"
 let tableDate = "tableDateLinux"
 let tableString = "tableStringLinux"
+let tableUUID = "tableUUIDLinux"
 #else
 let tableNumeric = "tableNumericOSX"
 let tableNumberTypes = "tableNumberTypesOSX"
 let tableBool = "tableBoolOSX"
 let tableDate = "tableDateOSX"
 let tableString = "tableStringOSX"
+let tableUUID = "tableUUIDOSX"
 #endif
 
 class TestTypes: XCTestCase {
@@ -44,6 +46,7 @@ class TestTypes: XCTestCase {
             ("testNumberTypes", testNumberTypes),
             ("testNumeric", testNumeric),
             ("testStringTypes", testStringTypes),
+            ("testUUID", testUUID),            
         ]
     }
     
@@ -520,6 +523,61 @@ class TestTypes: XCTestCase {
                             executeQuery(query: drop, connection: connection) { result, rows in
                                 XCTAssertEqual(result.success, true, "DROP TABLE failed")
                                 XCTAssertNil(result.asError, "Error in DELETE: \(result.asError!)")
+                            }
+                        }
+                    }
+                }
+            }
+            expectation.fulfill()
+        })
+    }
+    
+    class UUIDTable: Table {
+        let a = Column("a")
+        let b = Column("b")
+        
+        let tableName = tableUUID
+    }
+    
+    func testUUID() {
+        let t = UUIDTable()
+        
+        let pool = CommonUtils.sharedInstance.getConnectionPool()
+        performTest(asyncTasks: { expectation in
+            
+            guard let connection = pool.getConnection() else {
+                XCTFail("Failed to get connection")
+                return
+            }
+            
+            cleanUp(table: t.tableName, connection: connection) { result in
+                
+                executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b uuid)", connection: connection) { result, rows in
+                    XCTAssertEqual(result.success, true, "CREATE TABLE failed")
+                    XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
+                    
+                    let uuid1 = UUID().uuidString
+                    let uuid2 = UUID().uuidString
+                    
+                    let i1 = Insert(into: t, values: "apple", uuid1)
+                    executeQuery(query: i1, connection: connection) { result, rows in
+                        XCTAssertEqual(result.success, true, "INSERT failed")
+                        XCTAssertNil(result.asError, "Error in INSERT: \(result.asError!)")
+                        
+                        let i2 = Insert(into: t, values: "banana", Parameter())
+                        executeQueryWithParameters(query: i2, connection: connection, parameters: uuid2) { result, rows in
+                            XCTAssertEqual(result.success, true, "INSERT failed")
+                            XCTAssertNil(result.asError, "Error in INSERT: \(result.asError!)")
+                            
+                            let s1 = Select(from: t)
+                            executeQuery(query: s1, connection: connection) { result, rows in
+                                XCTAssertEqual(result.success, true, "SELECT failed")
+                                XCTAssertNil(result.asError, "Error in SELECT: \(result.asError!)")
+                                XCTAssertNotNil(rows, "SELECT returned no rows")
+                                XCTAssertEqual(rows!.count, 2, "INSERT returned wrong number of rows: \(rows!.count) instead of 2")
+                                
+                                XCTAssertEqual(rows![0][1]! as! String, uuid1, "Wrong value in row 0 column 1")
+                                XCTAssertEqual(rows![1][1]! as! String, uuid2, "Wrong value in row 1 column 1")
                             }
                         }
                     }


### PR DESCRIPTION
IBM-Swift/Swift-Kuery#70 Support UUIDs - pass them as Strings to and from database