### PR TITLE
Support prepared statements with connection pooling

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLPreparedStatement.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLPreparedStatement.swift
@@ -23,4 +23,6 @@ public struct PostgreSQLPreparedStatement: PreparedStatement {
     
     /// The name of the prepared statement.
     public let name: String
+    
+    let query: String
 }


### PR DESCRIPTION
IBM-Swift/Swift-Kuery#82 

Support prepared statements with connection pooling for PostgreSQL by keeping a set of prepared statements for each connection and creating a prepared statement on the database if necessary