### PR TITLE
Fix a bug in numeric values fetching

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLResultFetcher.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLResultFetcher.swift
@@ -154,6 +154,7 @@ public class PostgreSQLResultFetcher: ResultFetcher {
                 
             case .numeric:
                 // Numeric is a sequence of Int16's: number of digits, weight, sign, display scale, numeric digits
+                // https://www.postgresql.org/message-id/491DC5F3D279CD4EB4B157DDD62237F404E27FE9@zipwire.esri.com
                 let sign = PostgreSQLResultFetcher.int16NetworkToHost(from: value.advanced(by: 4))
                 if sign == -16384 { // 0xC000
                     return "NaN"
@@ -171,15 +172,20 @@ public class PostgreSQLResultFetcher: ResultFetcher {
                 
                 if weight >= 0 {
                     for i in 0 ... weight {
-                        let digitsAsInt16 = PostgreSQLResultFetcher.int16NetworkToHost(from: currentDigitData)
-                        if i == 0 {
-                            result += String(digitsAsInt16)
+                        if currentDigitNumber < numberOfDigits {
+                            let digitsAsInt16 = PostgreSQLResultFetcher.int16NetworkToHost(from: currentDigitData)
+                            if i == 0 {
+                                result += String(digitsAsInt16)
+                            }
+                            else {
+                                result +=  String(format: "%04d", digitsAsInt16)
+                            }
+                            currentDigitData = currentDigitData.advanced(by: 2)
+                            currentDigitNumber = i + 1
                         }
                         else {
-                            result +=  String(format: "%04d", digitsAsInt16)
+                            result += "0000"
                         }
-                        currentDigitData = currentDigitData.advanced(by: 2)
-                        currentDigitNumber = i + 1
                     }
                 }
                 

--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLResultFetcher.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLResultFetcher.swift
@@ -153,7 +153,15 @@ public class PostgreSQLResultFetcher: ResultFetcher {
                 return Float64(bitPattern: UInt64(bigEndian: data.withUnsafeBytes { $0.pointee } ))
                 
             case .numeric:
-                // Numeric is a sequence of Int16's: number of digits, weight, sign, display scale, numeric digits
+                // Numeric is a sequence of Int16's: number of digits, weight, sign, display scale, numeric digits.
+                // The numeric digits are stored in the form of a series of 16 bit base-10000 numbers each representing
+                // four decimal digits of the original number.
+                // For example, for -12345.12 the numeric value received from PostgreSQL will be
+                // 00030001 40000002 00010929 04b0
+                // The number of digits is 3, the digits are 0001 0929 04b0 (1 2345 12 decimal).
+                // The weight is 1, meaning there are two digits before the decimal point.
+                // The sign is 0x4000, meaning this is a negative number.
+                // The display scale is 2, meaning there are 2 "decimal" digits after the decimal point.
                 // https://www.postgresql.org/message-id/491DC5F3D279CD4EB4B157DDD62237F404E27FE9@zipwire.esri.com
                 let sign = PostgreSQLResultFetcher.int16NetworkToHost(from: value.advanced(by: 4))
                 if sign == -16384 { // 0xC000

--- a/Tests/SwiftKueryPostgreSQLTests/TestTypes.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestTypes.swift
@@ -267,10 +267,31 @@ class TestTypes: XCTestCase {
                                                             XCTAssertEqual(rows![4][3]! as! String, negativeLongNumber, "Wrong value in row 4 column 3")
                                                             XCTAssertEqual(rows![4][4]! as! String, "0", "Wrong value in row 4 column 4")
                                                             
-                                                            let drop = Raw(query: "DROP TABLE", table: t)
-                                                            executeQuery(query: drop, connection: connection) { result, rows in
-                                                                XCTAssertEqual(result.success, true, "DROP TABLE failed")
-                                                                XCTAssertNil(result.asError, "Error in DELETE: \(result.asError!)")
+                                                            i = Insert(into: t, values: "grape", "90000.0", "-400000000", "20000.000000000000000", "0.000000000000")
+                                                            executeQuery(query: i, connection: connection) { result, rows in
+                                                                XCTAssertEqual(result.success, true, "INSERT failed")
+                                                                XCTAssertNil(result.asError, "Error in INSERT: \(result.asError!)")
+                                                                
+                                                                executeQuery(query: s, connection: connection) { result, rows in
+                                                                    XCTAssertEqual(result.success, true, "SELECT failed")
+                                                                    XCTAssertNil(result.asError, "Error in SELECT: \(result.asError!)")
+                                                                    XCTAssertNotNil(rows, "SELECT returned no rows")
+                                                                    XCTAssertEqual(rows!.count, 6, "SELECT returned wrong number of rows")
+                                                                    XCTAssertEqual(rows![5].count, 5, "SELECT returned wrong number of columns")
+                                                                    
+                                                                    XCTAssertEqual(rows![5][0]! as! String, "grape")
+                                                                    XCTAssertEqual(rows![5][1]! as! String, "90000")
+                                                                    XCTAssertEqual(rows![5][2]! as! String, "-400000000")
+                                                                    XCTAssertEqual(rows![5][3]! as! String, "20000")
+                                                                    XCTAssertEqual(rows![5][4]! as! String, "0")
+                                                                    
+                                                                    let drop = Raw(query: "DROP TABLE", table: t)
+                                                                    executeQuery(query: drop, connection: connection) { result, rows in
+                                                                        XCTAssertEqual(result.success, true, "DROP TABLE failed")
+                                                                        XCTAssertNil(result.asError, "Error in DELETE: \(result.asError!)")
+                                                                        
+                                                                    }
+                                                                }
                                                             }
                                                         }
                                                     }


### PR DESCRIPTION
IBM-Swift/Swift-Kuery-PostgreSQL#20 Don't read digits beyond the digits boundary