### PR TITLE
fix formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ let connection = PostgreSQLConnection(host: host, port: port, options: [Connecti
 For more information please see [PostgreSQL manual](https://www.postgresql.org/docs/8.0/static/libpq.html#LIBPQ-CONNECT).
 
 <br>
+
 Alternatively, call:
+
 ```swift
 let connection = PostgreSQLConnection(url: URL(string: "Postgres://\(username):\(password)@\(host):\(port)")!))
 ```


### PR DESCRIPTION
Just noticed GitHub's Markdown processor left this line unformatted in the README.