### PR TITLE
Update README to reflect latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ let package = Package(
 	dependencies: [
 		.Package(url: "https://github.com/IBM-Swift/HeliumLogger.git",       majorVersion: 1, minor: 7),
 		.Package(url: "https://github.com/IBM-Swift/Kitura.git",             majorVersion: 1, minor: 7),
-		.Package(url: "https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL", majorVersion: 0, minor: 10)
+		.Package(url: "https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL", majorVersion: 0, minor: 12)
 	]
 )
 ```


### PR DESCRIPTION
As a new user of Kitura copying the package from the readme tripped me up when I was expecting some of the newer features released since v0.10.x.

Hopefully this will help other newbies avoid the same problem. 🙂