### PR TITLE
Fix select date test

### DIFF
--- a/Tests/SwiftKueryPostgreSQLTests/TestSelect.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestSelect.swift
@@ -91,7 +91,7 @@ class TestSelect: XCTestCase {
                             XCTAssertEqual(result.success, true, "SELECT failed")
                             XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                             XCTAssertNotNil(rows, "SELECT returned no rows")
-                            XCTAssertEqual(rows!.count, 3, "SELECT returned wrong number of rows: \(rows!.count) instead of 3")
+                            XCTAssertEqual(rows?.count, 3, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 3")
                             
                             let sd1 = Select.distinct(t.a, from: t)
                                 .where(t.a.like("b%") && t.b.isNotNull())
@@ -99,7 +99,7 @@ class TestSelect: XCTestCase {
                                 XCTAssertEqual(result.success, true, "SELECT failed")
                                 XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                 XCTAssertNotNil(rows, "SELECT returned no rows")
-                                XCTAssertEqual(rows!.count, 1, "SELECT returned wrong number of rows: \(rows!.count) instead of 1")
+                                XCTAssertEqual(rows?.count, 1, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 1")
                                 
                                 let s3 = Select(t.b, t.a, from: t)
                                     .where(((t.a == "banana") || (ucase(t.a) == "APPLE")) && (t.b == 27 || t.b == -7 || t.b == 17))
@@ -109,7 +109,7 @@ class TestSelect: XCTestCase {
                                     XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                     let resultSet = result.asResultSet!
                                     XCTAssertNotNil(rows, "SELECT returned no rows")
-                                    XCTAssertEqual(rows!.count, 4, "SELECT returned wrong number of rows: \(rows!.count) instead of 4")
+                                    XCTAssertEqual(rows?.count, 4, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 4")
                                     XCTAssertEqual(resultSet.titles[0], "b", "Wrong column name: \(resultSet.titles[0]) instead of b")
                                     XCTAssertEqual(resultSet.titles[1], "a", "Wrong column name: \(resultSet.titles[1]) instead of a")
                                     
@@ -123,10 +123,10 @@ class TestSelect: XCTestCase {
                                         XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                         XCTAssertNotNil(rows, "SELECT returned no rows")
                                         let resultSet = result.asResultSet!
-                                        XCTAssertEqual(rows!.count, 2, "SELECT returned wrong number of rows: \(rows!.count) instead of 2")
+                                        XCTAssertEqual(rows?.count, 2, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 2")
                                         XCTAssertEqual(resultSet.titles[0], "a", "Wrong column name: \(resultSet.titles[0]) instead of a")
-                                        XCTAssertEqual(rows![0][0]! as! String, "banana", "Wrong value in row 0 column 0")
-                                        XCTAssertEqual(rows![1][0]! as! String, "apple", "Wrong value in row 1 column 0")
+                                        XCTAssertEqual(rows?[0][0]! as! String, "banana", "Wrong value in row 0 column 0")
+                                        XCTAssertEqual(rows?[1][0]! as! String, "apple", "Wrong value in row 1 column 0")
                                         
                                         let s4Raw = Select(RawField("left(a, 2) as raw"), from: t)
                                             .where("b >= 0")
@@ -138,10 +138,10 @@ class TestSelect: XCTestCase {
                                             XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                             XCTAssertNotNil(rows, "SELECT returned no rows")
                                             let resultSet = result.asResultSet!
-                                            XCTAssertEqual(rows!.count, 2, "SELECT returned wrong number of rows: \(rows!.count) instead of 2")
+                                            XCTAssertEqual(rows?.count, 2, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 2")
                                             XCTAssertEqual(resultSet.titles[0], "raw", "Wrong column name: \(resultSet.titles[0]) instead of raw")
-                                            XCTAssertEqual(rows![0][0]! as! String, "ba", "Wrong value in row 0 column 0")
-                                            XCTAssertEqual(rows![1][0]! as! String, "ap", "Wrong value in row 1 column 0")
+                                            XCTAssertEqual(rows?[0][0]! as! String, "ba", "Wrong value in row 0 column 0")
+                                            XCTAssertEqual(rows?[1][0]! as! String, "ap", "Wrong value in row 1 column 0")
                                             
                                             let s5 = Select(t.a, t.b, from: t)
                                                 .limit(to: 2)
@@ -150,9 +150,9 @@ class TestSelect: XCTestCase {
                                                 XCTAssertEqual(result.success, true, "SELECT failed")
                                                 XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                                 XCTAssertNotNil(rows, "SELECT returned no rows")
-                                                XCTAssertEqual(rows!.count, 2, "SELECT returned wrong number of rows: \(rows!.count) instead of 2")
-                                                XCTAssertEqual(rows![0][0]! as! String, "banana", "Wrong value in row 0 column 0")
-                                                XCTAssertEqual(rows![1][0]! as! String, "banana", "Wrong value in row 1 column 0")
+                                                XCTAssertEqual(rows?.count, 2, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 2")
+                                                XCTAssertEqual(rows?[0][0]! as! String, "banana", "Wrong value in row 0 column 0")
+                                                XCTAssertEqual(rows?[1][0]! as! String, "banana", "Wrong value in row 1 column 0")
                                                 
                                                 let s6 = Select(ucase(t.a).as("upper case"), t.b, from: t)
                                                     .where(t.a.between("apra", and: "aprt"))
@@ -160,10 +160,10 @@ class TestSelect: XCTestCase {
                                                     XCTAssertEqual(result.success, true, "SELECT failed")
                                                     XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                                     XCTAssertNotNil(rows, "SELECT returned no rows")
-                                                    XCTAssertEqual(rows!.count, 1, "SELECT returned wrong number of rows: \(rows!.count) instead of 1")
+                                                    XCTAssertEqual(rows?.count, 1, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 1")
                                                     let resultSet = result.asResultSet!
                                                     XCTAssertEqual(resultSet.titles[0], "upper case", "Wrong column name: \(resultSet.titles[0]) instead of 'upper case'")
-                                                    XCTAssertEqual(rows![0][0]! as! String, "APRICOT", "Wrong value in row 0 column 0")
+                                                    XCTAssertEqual(rows?[0][0]! as! String, "APRICOT", "Wrong value in row 0 column 0")
                                                     
                                                     let s61 = Select(ucase(t.a).as("upper case"), t.b, from: t)
                                                         .where(t.a.between("apra", and: "aprt").isNotNull())
@@ -171,7 +171,7 @@ class TestSelect: XCTestCase {
                                                         XCTAssertEqual(result.success, true, "SELECT failed")
                                                         XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                                         XCTAssertNotNil(rows, "SELECT returned no rows")
-                                                        XCTAssertEqual(rows!.count, 6, "SELECT returned wrong number of rows: \(rows!.count) instead of 6")
+                                                        XCTAssertEqual(rows?.count, 6, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 6")
                                                         
                                                         let s7 = Select(from: t)
                                                             .where(t.a.in("apple", "lalala"))
@@ -179,8 +179,8 @@ class TestSelect: XCTestCase {
                                                             XCTAssertEqual(result.success, true, "SELECT failed")
                                                             XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                                             XCTAssertNotNil(rows, "SELECT returned no rows")
-                                                            XCTAssertEqual(rows!.count, 2, "SELECT returned wrong number of rows: \(rows!.count) instead of 2")
-                                                            XCTAssertEqual(rows![0][0]! as! String, "apple", "Wrong value in row 0 column 0")
+                                                            XCTAssertEqual(rows?.count, 2, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 2")
+                                                            XCTAssertEqual(rows?[0][0]! as! String, "apple", "Wrong value in row 0 column 0")
                                                             
                                                             let s8 = Select(from: t)
                                                                 .where("a IN ('apple', 'lalala')")
@@ -188,16 +188,16 @@ class TestSelect: XCTestCase {
                                                                 XCTAssertEqual(result.success, true, "SELECT failed")
                                                                 XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                                                 XCTAssertNotNil(rows, "SELECT returned no rows")
-                                                                XCTAssertEqual(rows!.count, 2, "SELECT returned wrong number of rows: \(rows!.count) instead of 2")
-                                                                XCTAssertEqual(rows![0][0]! as! String, "apple", "Wrong value in row 0 column 0")
+                                                                XCTAssertEqual(rows?.count, 2, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 2")
+                                                                XCTAssertEqual(rows?[0][0]! as! String, "apple", "Wrong value in row 0 column 0")
                                                                 
                                                                 let s9 = "Select * from \(t.tableName) where a IN ('apple', 'lalala')"
                                                                 executeRawQuery(s9, connection: connection) { result, rows in
                                                                     XCTAssertEqual(result.success, true, "SELECT failed")
                                                                     XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                                                     XCTAssertNotNil(rows, "SELECT returned no rows")
-                                                                    XCTAssertEqual(rows!.count, 2, "SELECT returned wrong number of rows: \(rows!.count) instead of 2")
-                                                                    XCTAssertEqual(rows![0][0]! as! String, "apple", "Wrong value in row 0 column 0")
+                                                                    XCTAssertEqual(rows?.count, 2, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 2")
+                                                                    XCTAssertEqual(rows?[0][0]! as! String, "apple", "Wrong value in row 0 column 0")
                                                                     
                                                                     let drop = Raw(query: "DROP TABLE", table: t)
                                                                     executeQuery(query: drop, connection: connection) { result, rows in
@@ -273,7 +273,7 @@ class TestSelect: XCTestCase {
                                                     XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                                     XCTAssertNotNil(rows, "SELECT returned no rows")
                                                     let resultSet = result.asResultSet!
-                                                    XCTAssertEqual(rows!.count, 2, "SELECT returned wrong number of rows: \(rows!.count) instead of 2")
+                                                    XCTAssertEqual(rows?.count, 2, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 2")
                                                     XCTAssertEqual(resultSet.titles.count, 6, "SELECT returned wrong number of columns: \(resultSet.titles.count) instead of 6")
                                                 }
                                             }
@@ -328,13 +328,13 @@ class TestSelect: XCTestCase {
                         
                         let s1 = Select(from: t)
                             .where(t.date >= Date(timeIntervalSince1970: 50000)
-                                && t.time.between(self.extractTime(from: Date(timeIntervalSince1970: 0)),
+                                && t.time.between("00:00:00",
                                                   and: self.extractTime(from: Date(timeIntervalSinceNow: 1000))))
                         executeQuery(query: s1, connection: connection) { result, rows in
                             XCTAssertEqual(result.success, true, "SELECT failed")
                             XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                             XCTAssertNotNil(rows, "SELECT returned no rows")
-                            XCTAssertEqual(rows!.count, 1, "SELECT returned wrong number of rows: \(rows!.count) instead of 1")
+                            XCTAssertEqual(rows?.count, 1, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 1")
                             
                             let i2 = Insert(into: t, values: "then", Date(timeIntervalSince1970: 0), Date(timeIntervalSince1970: 0), Date(timeIntervalSince1970: 0))
                             executeQuery(query: i2, connection: connection) { result, rows in
@@ -347,7 +347,7 @@ class TestSelect: XCTestCase {
                                     XCTAssertEqual(result.success, true, "SELECT failed")
                                     XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                     XCTAssertNotNil(rows, "SELECT returned no rows")
-                                    XCTAssertEqual(rows!.count, 1, "SELECT returned wrong number of rows: \(rows!.count) instead of 1")
+                                    XCTAssertEqual(rows?.count, 1, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 1")
                                     
                                     let s3 = Select(from: t)
                                         .where(now() > t.date)
@@ -355,7 +355,7 @@ class TestSelect: XCTestCase {
                                         XCTAssertEqual(result.success, true, "SELECT failed")
                                         XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
                                         XCTAssertNotNil(rows, "SELECT returned no rows")
-                                        XCTAssertEqual(rows!.count, 2, "SELECT returned wrong number of rows: \(rows!.count) instead of 2")
+                                        XCTAssertEqual(rows?.count, 2, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 2")
                                     }
                                 }
                             }


### PR DESCRIPTION
It appears the select date test was failing because the time range in the select statement was incorrect. I'm assuming the intention of using `Date(timeIntervalSince1970: 0)` was to get back a timestamp of `"00:00:00"`. If this is the case, the timestamp was actually the value for the date in the local time of the machine. This caused the range to be dependent on the time the tests were run and the locale of the machine. By explicitly setting the timestamp to `"00:00:00"` the test is no longer dependent on external factors.

Another issue with the tests was force unwrapping the rows variable. In the case of this failing test instead of seeing a failing test, the tests would simply stop executing because it would come upon an unexpected nil value.