### PR TITLE
fixed memory leak caused by PQprepare

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -294,6 +294,7 @@ public class PostgreSQLConnection: Connection {
                 }
                 return errorMessage
         }
+        PQclear(result)
         preparedStatements.insert(name)
         return nil
     }

--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -286,12 +286,14 @@ public class PostgreSQLConnection: Connection {
     }
     
     private func prepareStatement(name: String, for query: String) -> String? {
-        guard let result = PQprepare(connection, name, query, 0, nil),
-            PQresultStatus(result) == PGRES_COMMAND_OK else {
+        let result = PQprepare(connection, name, query, 0, nil)
+        let status = PQresultStatus(result)
+        if status != PGRES_COMMAND_OK {
                 var errorMessage = "Failed to create prepared statement."
                 if let error = String(validatingUTF8: PQerrorMessage(connection)) {
                     errorMessage += " Error: \(error)."
                 }
+                PQclear(result)
                 return errorMessage
         }
         PQclear(result)


### PR DESCRIPTION
Documentations says: "As with PQexec, the result is normally a PGresult object whose contents indicate server-side success or failure." 
This PGresult objects needs to be cleared with PQclear. "Every command result should be freed via PQclear when it is no longer needed."