### PR TITLE
fix: Postgres check lowercased

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -92,7 +92,7 @@ public class PostgreSQLConnection: Connection {
     
     private static func extractConnectionParameters(url: URL) -> String {
         var result = ""
-        if let scheme = url.scheme, scheme == "Postgres", let host = url.host, let port = url.port {
+        if let scheme = url.scheme, scheme.lowercased() == "postgres", let host = url.host, let port = url.port {
             result = "host = \(host) port = \(port)"
             if let user = url.user {
                 result += " user = \(user)"


### PR DESCRIPTION
ElephantSQL and other postgre services provide the URL with the structure "postgres://userid:pwd@host:port/db" where the p in postgres is lowercase. 
Currently we reject this since the scheme check fails however this is a valid URL.

This pull request changes the check to ignore type so it will now accept these URL's