### PR TITLE
Build column description in the plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/CLibpq.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "2.0.0"),
+        //.package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "2.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("issue_column_attributes") ),
         ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -594,7 +594,7 @@ class PostgreSQLColumnBuilder: ColumnCreator {
                 //Unrecognised type for autoIncrement column, return nil
                 return nil
             }
-            result += autoIncrementType + " AUTOINCREMENT"
+            result += autoIncrementType
         } else {
             result += typeString
         }
@@ -629,11 +629,11 @@ class PostgreSQLColumnBuilder: ColumnCreator {
     func getAutoIncrementType(for type: String) -> String? {
         switch type {
         case "smallint":
-            return "smallserial"
+            return "smallserial "
         case "integer":
-            return "serial"
+            return "serial "
         case "bigint":
-            return "bigserial"
+            return "bigserial "
         default:
             return nil
         }

--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017
+ Copyright IBM Corporation 2016, 2017, 2018
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKueryPostgreSQLTests/TestSchema.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestSchema.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2017
+ Copyright IBM Corporation 2017, 2018
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKueryPostgreSQLTests/TestSchema.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestSchema.swift
@@ -394,7 +394,7 @@ class TestSchema: XCTestCase {
     }
 
     class AutoIncrement3: Table {
-        let a = Column("a", String.self, primaryKey: true, defaultValue: "qiwi")
+        let a = Column("a", String.self, defaultValue: "qiwi")
         let b = Column("b", String.self, autoIncrement: true, primaryKey: true)
 
         let tableName = "AutoIncrement3" + tableNameSuffix


### PR DESCRIPTION
This PR updates the plugin to conform to the new QueryBuilder requirements and adds the logic to build a string representation of a column for the plugin.