### PR TITLE
Fixed a memory leak in `preparedStatements` set

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -347,6 +347,8 @@ public class PostgreSQLConnection: Connection {
     /// - Parameter preparedStatement: The prepared statement to release.
     /// - Parameter onCompletion: The function to be called when the execution has completed.
     public func release(preparedStatement: PreparedStatement, onCompletion: @escaping ((QueryResult) -> ())) {
+        // Remove entry from preparedStatements
+        preparedStatements.remove(preparedStatement.name)
         // No need to deallocate prepared statements in PostgreSQL.
         onCompletion(.successNoData)
     }


### PR DESCRIPTION
The property `preparedStatements` stores prepared statements (namely, name + query).  
While the `prepare` method adds an entry to the set, nothing ever takes care of removing these entries, even when `release` is explicitly called.