### PR TITLE
Added `deinit`, closes a connection

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -193,8 +193,13 @@ public class PostgreSQLConnection: Connection {
     
     /// Close the connection to the database.
     public func closeConnection() {
-        PQfinish(connection)
-        connection = nil
+        if let connection = connection {
+            PQfinish(connection)
+            connection = nil
+        }
+    }
+    deinit {
+         closeConnection()
     }
     
     /// Execute a query with parameters.


### PR DESCRIPTION
If you use a standalone connection (not via a connection pool), it just leaks.
Added a destructor, and made `closeConnection` work if called more than once (which should have been the case regardless of the destructor)