### PR TITLE
Added a destructor

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -193,10 +193,16 @@ public class PostgreSQLConnection: Connection {
     
     /// Close the connection to the database.
     public func closeConnection() {
-        PQfinish(connection)
-        connection = nil
+        if let connection = connection {
+            PQfinish(connection)
+            self.connection = nil
+        }
     }
-    
+ 
+    deinit {
+        closeConnection()
+    }    
+ 
     /// Execute a query with parameters.
     ///
     /// - Parameter query: The query to execute.


### PR DESCRIPTION
Made it possible to call `closeConnection` on a closed connection and added a destructor.
Without the destructor, a connection that is used without a connection pool (standalone) will just leak connections for each instance created.
The other drivers (sqlite and mysql) have a destructor that does exactly the same, this driver should not be any different.