### PR TITLE
Build against Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
     - os: osx
       osx_image: xcode9.2
       sudo: required
@@ -36,6 +40,10 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 services:
   - postgresql

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .systemLibrary(
             name: "CLibpq",
-            pkgConfig: "libpq"
+            pkgConfig: "libpq",
+            providers: [
+                .brew(["postgresql"]),
+                .apt(["libpq-dev"])
+            ]
         ),
         .target(
             name: "SwiftKueryPostgreSQL",

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -1,8 +1,8 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /**
- * Copyright IBM Corporation 2016, 2018
+ * Copyright IBM Corporation 2016, 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,18 +28,15 @@ let package = Package(
         )
     ],
     dependencies: [
+        .package(url: "https://github.com/IBM-Swift/CLibpq.git", .upToNextMinor(from: "0.1.0")),
         .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("next")),
         ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .systemLibrary(
-            name: "CLibpq",
-            pkgConfig: "libpq"
-        ),
         .target(
             name: "SwiftKueryPostgreSQL",
-            dependencies: ["SwiftKuery", "CLibpq"]
+            dependencies: ["SwiftKuery"]
         ),
         .testTarget(
             name: "SwiftKueryPostgreSQLTests",

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -1,8 +1,8 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /**
- * Copyright IBM Corporation 2016, 2018
+ * Copyright IBM Corporation 2016, 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,18 +28,15 @@ let package = Package(
         )
     ],
     dependencies: [
+        .package(url: "https://github.com/IBM-Swift/CLibpq.git", .upToNextMinor(from: "0.1.0")),
         .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("next")),
         ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .systemLibrary(
-            name: "CLibpq",
-            pkgConfig: "libpq"
-        ),
         .target(
             name: "SwiftKueryPostgreSQL",
-            dependencies: ["SwiftKuery", "CLibpq"]
+            dependencies: ["SwiftKuery"]
         ),
         .testTarget(
             name: "SwiftKueryPostgreSQLTests",

--- a/Sources/CLibpq/module.modulemap
+++ b/Sources/CLibpq/module.modulemap
@@ -1,0 +1,21 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+ 
+ module CLibpq {
+    header "shim.h"
+    link "pq"
+    export *
+ }

--- a/Sources/CLibpq/shim.h
+++ b/Sources/CLibpq/shim.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+
+#ifndef libpq_shim_h
+#define libpq_shim_h
+
+#import <libpq-fe.h>
+
+#endif


### PR DESCRIPTION
Adds testing with a Swift 5 development snapshot. The snapshot is defined in Travis as `SWIFT_DEVELOPMENT_SNAPSHOT` consistently across the IBM-Swift repos, to enable us to automate updating the version.

Compilation warnings are addressed via https://github.com/IBM-Swift/Swift-Kuery/pull/164

Embeds the CLibpq system library in the package for Swift 4.2 and higher, and introduces a 4.0 and 4.1 Package.swift for backward compatibility.