### PR TITLE
Issue remove timeout

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/CLibpq.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("next")),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("issue_remove_timeout")),
         ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Tests/SwiftKueryPostgreSQLTests/CommonUtils.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/CommonUtils.swift
@@ -191,7 +191,7 @@ class CommonUtils {
         let username = read(fileName: "username.txt")
         let password = read(fileName: "password.txt")
         
-        pool = PostgreSQLConnection.createPool(host: host, port: port, options: [.userName(username), .password(password)], poolOptions: ConnectionPoolOptions(initialCapacity: 0, maxCapacity: 1, timeout: 10000))
+        pool = PostgreSQLConnection.createPool(host: host, port: port, options: [.userName(username), .password(password)], poolOptions: ConnectionPoolOptions(initialCapacity: 0, maxCapacity: 1))
         return pool!
     }
     
@@ -201,7 +201,7 @@ class CommonUtils {
         let username = read(fileName: "username.txt")
         let password = read(fileName: "password.txt")
         
-        pool = PostgreSQLConnection.createPool(host: host, port: port, options: [.userName(username), .password(password)], poolOptions: ConnectionPoolOptions(initialCapacity: 0, maxCapacity: 1, timeout: 10000))
+        pool = PostgreSQLConnection.createPool(host: host, port: port, options: [.userName(username), .password(password)], poolOptions: ConnectionPoolOptions(initialCapacity: 0, maxCapacity: 1))
         return pool!
     }
 


### PR DESCRIPTION
The PR removes the timeout from connection pool options in line with the latest Swift Kuery changes.