### PR TITLE
Deallocate prepared statements

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -362,8 +362,8 @@ public class PostgreSQLConnection: Connection {
             if let _ = dealloc_result.asError {
                 result = dealloc_result
             }
+            return self.runCompletionHandler(result ?? .successNoData, onCompletion: onCompletion)
         }
-        return runCompletionHandler(result ?? .successNoData, onCompletion: onCompletion)
     }
 
     private func execute(query: String?, preparedStatement: PreparedStatement?, with parameters: [Any?], onCompletion: @escaping ((QueryResult) -> ())) {

--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -356,8 +356,14 @@ public class PostgreSQLConnection: Connection {
         }
         // Remove entry from the preparedStatements set
         preparedStatements.remove(statement.name)
-        // No need to deallocate prepared statements in PostgreSQL.
-        return runCompletionHandler(.successNoData, onCompletion: onCompletion)
+        // Deallocate prepared statement
+        var result:QueryResult?
+        self.execute("DEALLOCATE \"\(statement.name)\"") { (dealloc_result:QueryResult) in
+            if let _ = dealloc_result.asError {
+                result = dealloc_result
+            }
+        }
+        return runCompletionHandler(result ?? .successNoData, onCompletion: onCompletion)
     }
 
     private func execute(query: String?, preparedStatement: PreparedStatement?, with parameters: [Any?], onCompletion: @escaping ((QueryResult) -> ())) {

--- a/Tests/SwiftKueryPostgreSQLTests/TestParameters.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestParameters.swift
@@ -281,30 +281,42 @@ class TestParameters: XCTestCase {
                                                     XCTAssertNotNil(rows, "SELECT returned no rows")
                                                     XCTAssertEqual(rows.count, 2, "Wrong number of rows")
 
-                                                    let s2 = "SELECT * FROM \"" + t.tableName + "\""
-                                                    connection.prepareStatement(s2) { result in
-                                                        guard let preparedSelect2 = result.asPreparedStatement else {
-                                                            if let error = result.asError {
-                                                                XCTFail("Unable to prepare statement preparedSelect2: \(error.localizedDescription)")
-                                                            }
-                                                            XCTFail("Unable to prepare statement preparedSelect2")
-                                                            expectation.fulfill()
-                                                            return
+                                                    connection.release(preparedStatement: preparedSelect) { result in
+                                                        if let error = result.asError {
+                                                            XCTFail("Error releasing prepared statement: \(error)")
                                                         }
-
-                                                        connection.execute(preparedStatement: preparedSelect2) { result in
-                                                            XCTAssertEqual(result.success, true, "SELECT failed")
-                                                            XCTAssertNil(result.asError)
-                                                            result.asRows() { rows, error in
-                                                                guard let rows = rows else {
-                                                                return XCTFail("Query expected to return a row")
+                                                        XCTAssertEqual(result.success, true, "Expected a successNoData result but was: \(result)")
+                                                        let s2 = "SELECT * FROM \"" + t.tableName + "\""
+                                                        connection.prepareStatement(s2) { result in
+                                                            guard let preparedSelect2 = result.asPreparedStatement else {
+                                                                if let error = result.asError {
+                                                                    XCTFail("Unable to prepare statement preparedSelect2: \(error.localizedDescription)")
                                                                 }
-                                                                XCTAssertNotNil(rows, "SELECT returned no rows")
-                                                                XCTAssertEqual(rows.count, 3, "Wrong number of rows")
+                                                                XCTFail("Unable to prepare statement preparedSelect2")
                                                                 expectation.fulfill()
+                                                                return
                                                             }
-                                                        }
 
+                                                            connection.execute(preparedStatement: preparedSelect2) { result in
+                                                                XCTAssertEqual(result.success, true, "SELECT failed")
+                                                                XCTAssertNil(result.asError)
+                                                                result.asRows() { rows, error in
+                                                                    guard let rows = rows else {
+                                                                    return XCTFail("Query expected to return a row")
+                                                                    }
+                                                                    XCTAssertNotNil(rows, "SELECT returned no rows")
+                                                                    XCTAssertEqual(rows.count, 3, "Wrong number of rows")
+                                                                    connection.release(preparedStatement: preparedSelect2) { result in
+                                                                        if let error = result.asError {
+                                                                            XCTFail("Error releasing prepared statement: \(error)")
+                                                                        }
+                                                                        XCTAssertEqual(result.success, true, "Expected a successNoData result but was: \(result)")
+                                                                        expectation.fulfill()
+                                                                    }
+                                                                }
+                                                            }
+
+                                                        }
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
The comment: `No need to deallocate prepared statements in PostgreSQL.` is wrong.  
While `libpq` does not have a wrapper for this, all statements must be deallocate using "DEALLOCATE".  
See https://www.postgresql.org/docs/current/libpq-exec.html (look for DEALLOCATE)