### PR TITLE
Add deinit for connections, reinstate tests

### DIFF
--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -208,8 +208,14 @@ public class PostgreSQLConnection: Connection {
     
     /// Close the connection to the database.
     public func closeConnection() {
-        PQfinish(connection)
-        connection = nil
+        if let connection = self.connection {
+            PQfinish(connection)
+            self.connection = nil
+        }
+    }
+
+    deinit {
+        closeConnection()
     }
 
     /// Execute a query with parameters.

--- a/Tests/SwiftKueryPostgreSQLTests/TestSchema.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestSchema.swift
@@ -31,10 +31,10 @@ class TestSchema: XCTestCase {
     static var allTests: [(String, (TestSchema) -> () throws -> Void)] {
         return [
             ("testCreateTable", testCreateTable),
-//            ("testForeignKeys", testForeignKeys),
-//            ("testPrimaryKeys", testPrimaryKeys),
-//            ("testTypes", testTypes),
-//            ("testAutoIncrement", testAutoIncrement),
+            ("testForeignKeys", testForeignKeys),
+            ("testPrimaryKeys", testPrimaryKeys),
+            ("testTypes", testTypes),
+            ("testAutoIncrement", testAutoIncrement),
         ]
     }
     


### PR DESCRIPTION
This PR adds a deinit method for connections to ensure they are released where a user has not explicitly closed them.

Also noticed some tests erroneously commented out so reinstated them.