### PR TITLE
Enhance support for nil values

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        //.package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("insert_nulls_property")),
         ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -29,7 +29,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/CLibpq.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        //.package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("insert_nulls_property")),
         ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -29,7 +29,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/CLibpq.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        //.package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("insert_nulls_property")),
         ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -28,7 +28,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        //.package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("insert_nulls_property")),
         ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017, 2018
+ Copyright IBM Corporation 2016, 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/SwiftKueryPostgreSQL/PostgreSQLConnection.swift
@@ -649,14 +649,8 @@ class PostgreSQLColumnBuilder: ColumnCreator {
         if column.isUnique {
             result += " UNIQUE"
         }
-        if let defaultValue = column.defaultValue {
-            var packedType: String
-            do {
-                packedType = try packType(defaultValue, queryBuilder: queryBuilder)
-            } catch {
-                return nil
-            }
-            result += " DEFAULT " + packedType
+        if let defaultValue = getDefaultValue(for: column, queryBuilder: queryBuilder) {
+            result += " DEFAULT " + defaultValue
         }
         if let checkExpression = column.checkExpression {
             result += checkExpression.contains(column.name) ? " CHECK (" + checkExpression.replacingOccurrences(of: column.name, with: "\"\(column.name)\"") + ")" : " CHECK (" + checkExpression + ")"
@@ -677,25 +671,6 @@ class PostgreSQLColumnBuilder: ColumnCreator {
             return "bigserial "
         default:
             return nil
-        }
-    }
-
-    func packType(_ item: Any, queryBuilder: QueryBuilder) throws -> String {
-        switch item {
-        case let val as String:
-            return "'\(val)'"
-        case let val as Bool:
-            return val ? queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.booleanTrue.rawValue]
-                : queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.booleanFalse.rawValue]
-        case let val as Parameter:
-            return try val.build(queryBuilder: queryBuilder)
-        case let value as Date:
-            if let dateFormatter = queryBuilder.dateFormatter {
-                return dateFormatter.string(from: value)
-            }
-            return "'\(String(describing: value))'"
-        default:
-            return String(describing: item)
         }
     }
 }

--- a/Tests/SwiftKueryPostgreSQLTests/TestInsert.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestInsert.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017
+ Copyright IBM Corporation 2016, 2017, 2018, 2019
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKueryPostgreSQLTests/TestInsert.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestInsert.swift
@@ -23,10 +23,12 @@ import SwiftKuery
 let tableInsert = "tableInsertLinux"
 let tableInsert2 = "tableInsert2Linux"
 let tableInsert3 = "tableInsert3Linux"
+let tableInsert4 = "tableInsert4Linux"
 #else
 let tableInsert = "tableInsertOSX"
 let tableInsert2 = "tableInsert2OSX"
 let tableInsert3 = "tableInsert3OSX"
+let tableInsert4 = "tableInsert4OSX"
 #endif
 
 class TestInsert: XCTestCase {
@@ -34,7 +36,8 @@ class TestInsert: XCTestCase {
     static var allTests: [(String, (TestInsert) -> () throws -> Void)] {
         return [
             ("testInsert", testInsert),
-            ("testInsertID", testInsertID)
+            ("testInsertID", testInsertID),
+            ("testInsertNil", testInsertNil),
         ]
     }
 
@@ -58,6 +61,14 @@ class TestInsert: XCTestCase {
 
         let tableName = tableInsert3
     }
+
+    class MyTable4 : Table {
+        let a = Column("a", String.self)
+        let b = Column("b", Int64.self, autoIncrement:true, primaryKey: true)
+
+        let tableName = tableInsert4
+    }
+
     func testInsert() {
         let t = MyTable()
         let t2 = MyTable2()
@@ -227,6 +238,49 @@ class TestInsert: XCTestCase {
 
                                 let dropT3 = Raw(query: "DROP TABLE", table: t3)
                                 executeQuery(query: dropT3, connection: connection) { result, rows in
+                                    XCTAssertEqual(result.success, true, "DROP TABLE failed")
+                                    XCTAssertNil(result.asError, "Error in DELETE: \(result.asError!)")
+                                    expectation.fulfill()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    func testInsertNil() {
+        let t = MyTable4()
+
+        let pool = CommonUtils.sharedInstance.getConnectionPool()
+        performTest(asyncTasks: { expectation in
+            pool.getConnection { connection, error in
+                guard let connection = connection else {
+                    XCTFail("Failed to get connection")
+                    return
+                }
+                cleanUp(table: t.tableName, connection: connection) { result in
+                    executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a TEXT, b SERIAL PRIMARY KEY)", connection: connection) { result, rows in
+                        XCTAssertEqual(result.success, true, "CREATE TABLE failed")
+                        XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
+
+                        let optionalString: String? = nil
+                        let insertNil = Insert(into: t, valueTuples: [(t.a, optionalString)])
+                        executeQuery(query: insertNil, connection: connection) { result, rows in
+                            XCTAssertEqual(result.success, true, "INSERT failed")
+                            XCTAssertNil(result.asError, "Error in INSERT: \(result.asError!)")
+
+                            let select = Select(from: t)
+                            executeQuery(query: select, connection: connection) { result, rows in
+                                XCTAssertEqual(result.success, true, "SELECT failed")
+                                XCTAssertNil(result.asError, "Error in SELECT: \(result.asError!)")
+                                XCTAssertNotNil(rows, "SELECT returned no rows")
+                                XCTAssertEqual(rows?.count, 1, "SELECT returned wrong number of rows: \(String(describing: rows?.count)) instead of 1")
+                                XCTAssertNil(rows?[0][0], "Expected value `nil` not found, returned: \(String(describing: rows?[0][0])) instead")
+
+                                let drop = Raw(query: "DROP TABLE", table: t)
+                                executeQuery(query: drop, connection: connection) { result, rows in
                                     XCTAssertEqual(result.success, true, "DROP TABLE failed")
                                     XCTAssertNil(result.asError, "Error in DELETE: \(result.asError!)")
                                     expectation.fulfill()

--- a/Tests/SwiftKueryPostgreSQLTests/TestSchema.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestSchema.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2017, 2018
+ Copyright IBM Corporation 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKueryPostgreSQLTests/TestSchema.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestSchema.swift
@@ -35,6 +35,7 @@ class TestSchema: XCTestCase {
             ("testPrimaryKeys", testPrimaryKeys),
             ("testTypes", testTypes),
             ("testAutoIncrement", testAutoIncrement),
+            ("testCreateTableNilDefault", testCreateTableNilDefault),
         ]
     }
     
@@ -444,6 +445,51 @@ class TestSchema: XCTestCase {
                                         expectation.fulfill()
                                     }
                                 }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    class MyNilDefaultTable: Table {
+        let a = Column("a", String.self, defaultValue: nil, nullDefaultValue: true)
+        let b = Column("b", Int64.self, autoIncrement: true, primaryKey: true)
+        let c = Column("c", Int64.self)
+
+        let tableName = "MyNilDefaultTable" + tableNameSuffix
+    }
+
+    func testCreateTableNilDefault() {
+        let t = MyNilDefaultTable()
+
+        let pool = CommonUtils.sharedInstance.getConnectionPool()
+        performTest(asyncTasks: { expectation in
+
+            pool.getConnection { connection, error in
+                guard let connection = connection else {
+                    XCTFail("Failed to get connection")
+                    return
+                }
+                cleanUp(table: t.tableName, connection: connection) { _ in
+                    t.create(connection: connection) { result in
+                        if let error = result.asError {
+                            XCTFail("Error in CREATE TABLE: \(error)")
+                            return
+                        }
+
+                        let insert = Insert(into: t, columns: [t.c], values: [5])
+                        executeQuery(query: insert, connection: connection) { result, rows in
+                            XCTAssertNil(result.asError, "Error in INSERT")
+
+                            let select = Select(from: t)
+                            executeQuery(query: select, connection: connection) { result, rows in
+                                XCTAssertNil(result.asError, "Error on SELECT")
+                                XCTAssertNotNil(rows, "Expected rows but none returned")
+                                XCTAssertNil(rows?[0][0], "Non nil default value stored, expecting nil but returned \(String(describing: rows?[0][0]))")
+
+                                expectation.fulfill()
                             }
                         }
                     }

--- a/Tests/SwiftKueryPostgreSQLTests/TestUpdate.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestUpdate.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017
+ Copyright IBM Corporation 2016, 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKueryPostgreSQLTests/TestUpdate.swift
+++ b/Tests/SwiftKueryPostgreSQLTests/TestUpdate.swift
@@ -30,6 +30,7 @@ class TestUpdate: XCTestCase {
     static var allTests: [(String, (TestUpdate) -> () throws -> Void)] {
         return [
             ("testUpdateAndDelete", testUpdateAndDelete),
+            ("testUpdateNilValue", testUpdateNilValue),
         ]
     }
     
@@ -133,6 +134,51 @@ class TestUpdate: XCTestCase {
                                             }
                                         }
                                     }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    func testUpdateNilValue() {
+        let t = MyTable()
+
+        let pool = CommonUtils.sharedInstance.getConnectionPool()
+        performTest(asyncTasks: { expectation in
+
+            pool.getConnection { connection, error in
+                guard let connection = connection else {
+                    XCTFail("Failed to get connection")
+                    return
+                }
+                cleanUp(table: t.tableName, connection: connection) { _ in
+
+                    executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
+                        XCTAssertEqual(result.success, true, "CREATE TABLE failed")
+                        XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
+
+                        let insert = Insert(into: t, rows: [["apple", 10], ["apricot", 3], ["banana", 17], ["apple", 17], ["banana", -7], ["banana", 27]])
+                        executeQuery(query: insert, connection: connection) { result, rows in
+                            XCTAssertEqual(result.success, true, "INSERT failed")
+                            XCTAssertNil(result.asError, "Error in INSERT: \(result.asError!)")
+
+                            let update = Update(t, set:[(t.a, nil)], where: t.a == "apple")
+                            executeQuery(query: update, connection: connection) { result, rows in
+                                XCTAssertEqual(result.success, true, "UPDATE failed")
+                                XCTAssertNil(result.asError, "Error in UPDATE: \(result.asError!)")
+
+                                let select = Select(from: t)
+                                executeQuery(query: select, connection: connection) { result, rows in
+                                    XCTAssertEqual(result.success, true, "SELECT failed")
+                                    XCTAssertNil(result.asError, "Error in SELECT: \(result.asError!)")
+                                    XCTAssertNotNil(rows, "Expected rows but none returned")
+                                    for row in rows! {
+                                        XCTAssertNotEqual(row[0] as? String, "apple", "Row returned with \"apple\" instead of expected value \"nil\"")
+                                    }
+                                    expectation.fulfill()
                                 }
                             }
                         }


### PR DESCRIPTION
This PR adds support for using nil to represent NULL for default column values.

The PR also adds test for inset, update and table creation when using nil values.